### PR TITLE
feat: Implement javax.crypto.Cipher with AES-GCM and AES-CBC support

### DIFF
--- a/scala-native-crypto/src/com/github/lolgab/scalanativecrypto/OpenSslProvider.scala
+++ b/scala-native-crypto/src/com/github/lolgab/scalanativecrypto/OpenSslProvider.scala
@@ -1,6 +1,6 @@
 package com.github.lolgab.scalanativecrypto
 
-import com.github.lolgab.scalanativecrypto.services._
+import com.github.lolgab.scalanativecrypto.services.{OpenSslCipherService, _}
 
 import java.security.Provider
 import java.util.Objects.requireNonNull
@@ -111,6 +111,18 @@ class OpenSslProvider(
         )
       ) {
         val svc = OpenSslMessageDigestService(this, algo, aliases, JMap.of())
+        putService(svc)
+        aliases.forEach(alias => putAliasService(svc, alias))
+      }
+
+      // Register Cipher services
+      for (
+        (transformation, aliases) <- Seq(
+          ("AES/GCM/NoPadding", JList.of[String]()),
+          ("AES/CBC/PKCS5Padding", JList.of[String]("AES/CBC/PKCS7Padding"))
+        )
+      ) {
+        val svc = OpenSslCipherService(this, transformation, aliases, JMap.of())
         putService(svc)
         aliases.forEach(alias => putAliasService(svc, alias))
       }

--- a/scala-native-crypto/src/com/github/lolgab/scalanativecrypto/crypto/Cipher.scala
+++ b/scala-native-crypto/src/com/github/lolgab/scalanativecrypto/crypto/Cipher.scala
@@ -1,0 +1,419 @@
+package com.github.lolgab.scalanativecrypto.crypto
+
+import com.github.lolgab.scalanativecrypto.internal.Constants._
+import com.github.lolgab.scalanativecrypto.internal._
+
+import java.com.github.lolgab.scalanativecrypto.internal.CtxFinalizer
+import java.security.{InvalidAlgorithmParameterException, InvalidKeyException, Key, Provider}
+import java.security.spec.AlgorithmParameterSpec
+import javax.crypto.{AEADBadTagException, BadPaddingException, Cipher}
+import javax.crypto.spec.{GCMParameterSpec, IvParameterSpec, SecretKeySpec}
+import scala.scalanative.meta.LinktimeInfo
+import scala.scalanative.runtime.ByteArray
+import scala.scalanative.unsafe._
+
+/**
+ * OpenSSL-backed Cipher implementation supporting AES/GCM/NoPadding and
+ * AES/CBC/PKCS5Padding.
+ */
+final class OpenSslCipher protected[scalanativecrypto] (
+    provider: Provider,
+    transformation: String,
+    mode: String,
+    padding: String
+) extends Cipher(null, provider, transformation) {
+
+  private val ctx: crypto.EVP_CIPHER_CTX_* = crypto.EVP_CIPHER_CTX_new()
+  if (ctx == null) {
+    throw new RuntimeException("Failed to create cipher context")
+  }
+
+  if (LinktimeInfo.isWeakReferenceSupported) {
+    CtxFinalizer.register_EVP_CIPHER_CTX(this, ctx)
+  } else {
+    System.err.println(
+      "[javax.crypto.Cipher] OpenSSL context finalization is not supported. Consider using immix or commix GC, otherwise this will leak memory."
+    )
+  }
+
+  private var opmode: Int = -1
+  private var isGcm: Boolean = mode == "GCM"
+  private var gcmTagLen: Int = 16 // default 128-bit tag
+  private var iv: Array[Byte] = _
+  private var initialized: Boolean = false
+
+  // Accumulated data for GCM (we need to buffer for tag handling)
+  private var accumulated: Array[Byte] = Array.empty
+
+  override def getBlockSize(): Int =
+    if (isGcm) 1 // GCM is a stream cipher mode
+    else 16 // AES block size for CBC
+
+  override def getIV(): Array[Byte] =
+    if (iv == null) null else iv.clone()
+
+  override def init(opmode: Int, key: Key): Unit =
+    init(opmode, key, null: AlgorithmParameterSpec)
+
+  override def init(opmode: Int, key: Key, params: AlgorithmParameterSpec): Unit = {
+    require(
+      opmode == Cipher.ENCRYPT_MODE || opmode == Cipher.DECRYPT_MODE,
+      s"Unsupported opmode: $opmode"
+    )
+    this.opmode = opmode
+    this.accumulated = Array.empty
+
+    val keySpec = key match {
+      case k: SecretKeySpec => k
+      case _ => throw new InvalidKeyException("Only SecretKeySpec is supported")
+    }
+    val keyBytes = keySpec.getEncoded()
+
+    // Determine the EVP_CIPHER based on key size and mode
+    val evpCipher = (keyBytes.length, mode) match {
+      case (16, "GCM") => crypto.EVP_aes_128_gcm()
+      case (32, "GCM") => crypto.EVP_aes_256_gcm()
+      case (16, "CBC") => crypto.EVP_aes_128_cbc()
+      case (32, "CBC") => crypto.EVP_aes_256_cbc()
+      case (len, _) =>
+        throw new InvalidKeyException(
+          s"Invalid AES key length: ${len * 8} bits"
+        )
+    }
+
+    // Extract IV/nonce from params
+    val ivBytes: Array[Byte] = params match {
+      case gcm: GCMParameterSpec =>
+        if (!isGcm)
+          throw new InvalidAlgorithmParameterException(
+            "GCMParameterSpec used with non-GCM cipher"
+          )
+        gcmTagLen = gcm.getTLen() / 8
+        gcm.getIV()
+      case ivp: IvParameterSpec =>
+        ivp.getIV()
+      case null =>
+        throw new InvalidAlgorithmParameterException(
+          "Parameters required for AES cipher"
+        )
+      case _ =>
+        throw new InvalidAlgorithmParameterException(
+          s"Unsupported parameter type: ${params.getClass.getName}"
+        )
+    }
+    this.iv = ivBytes
+
+    // Reset context
+    crypto.EVP_CIPHER_CTX_reset(ctx)
+
+    if (isGcm) {
+      // For GCM: init cipher, set IV length, then set key+IV
+      val initFn =
+        if (opmode == Cipher.ENCRYPT_MODE) crypto.EVP_EncryptInit_ex _
+        else crypto.EVP_DecryptInit_ex _
+
+      if (initFn(ctx, evpCipher, null, null, null) != 1)
+        throw new RuntimeException("Failed to initialize cipher")
+
+      if (
+        crypto.EVP_CIPHER_CTX_ctrl(
+          ctx,
+          EVP_CTRL_AEAD_SET_IVLEN,
+          ivBytes.length,
+          null
+        ) != 1
+      )
+        throw new RuntimeException("Failed to set IV length")
+
+      if (initFn(ctx, null, null, keyBytes.at(0), ivBytes.at(0)) != 1)
+        throw new RuntimeException("Failed to set key and IV")
+    } else {
+      // For CBC: straightforward init
+      if (ivBytes.length != 16)
+        throw new InvalidAlgorithmParameterException(
+          s"Wrong IV length: must be 16 bytes, got ${ivBytes.length}"
+        )
+
+      val initFn =
+        if (opmode == Cipher.ENCRYPT_MODE) crypto.EVP_EncryptInit_ex _
+        else crypto.EVP_DecryptInit_ex _
+
+      if (initFn(ctx, evpCipher, null, keyBytes.at(0), ivBytes.at(0)) != 1)
+        throw new RuntimeException("Failed to initialize cipher")
+    }
+
+    initialized = true
+  }
+
+  override def updateAAD(src: Array[Byte]): Unit =
+    updateAAD(src, 0, src.length)
+
+  override def updateAAD(src: Array[Byte], offset: Int, len: Int): Unit = {
+    require(initialized, "Cipher not initialized")
+    require(isGcm, "AAD is only supported for GCM mode")
+
+    if (len > 0) {
+      val outl = stackalloc[CInt]()
+      val dataPtr = src.asInstanceOf[ByteArray].at(offset)
+
+      val rc =
+        if (opmode == Cipher.ENCRYPT_MODE)
+          crypto.EVP_EncryptUpdate(ctx, null, outl, dataPtr, len)
+        else
+          crypto.EVP_DecryptUpdate(ctx, null, outl, dataPtr, len)
+
+      if (rc != 1)
+        throw new RuntimeException("Failed to process AAD")
+    }
+  }
+
+  override def update(input: Array[Byte]): Array[Byte] =
+    update(input, 0, input.length)
+
+  override def update(
+      input: Array[Byte],
+      inputOffset: Int,
+      inputLen: Int
+  ): Array[Byte] = {
+    require(initialized, "Cipher not initialized")
+
+    if (isGcm) {
+      // For GCM, accumulate data and process in doFinal
+      // This simplifies tag handling
+      val chunk = new Array[Byte](inputLen)
+      System.arraycopy(input, inputOffset, chunk, 0, inputLen)
+      accumulated = accumulated ++ chunk
+      Array.empty[Byte]
+    } else {
+      // For CBC, process immediately
+      val maxOut = inputLen + 16 // at most one extra block
+      val outBuf = new Array[Byte](maxOut)
+      val outl = stackalloc[CInt]()
+      val inPtr = input.asInstanceOf[ByteArray].at(inputOffset)
+
+      val rc =
+        if (opmode == Cipher.ENCRYPT_MODE)
+          crypto.EVP_EncryptUpdate(
+            ctx,
+            outBuf.asInstanceOf[ByteArray].at(0),
+            outl,
+            inPtr,
+            inputLen
+          )
+        else
+          crypto.EVP_DecryptUpdate(
+            ctx,
+            outBuf.asInstanceOf[ByteArray].at(0),
+            outl,
+            inPtr,
+            inputLen
+          )
+
+      if (rc != 1)
+        throw new RuntimeException("Failed to update cipher")
+
+      val written = !outl
+      val result = new Array[Byte](written)
+      System.arraycopy(outBuf, 0, result, 0, written)
+      result
+    }
+  }
+
+  override def doFinal(): Array[Byte] = doFinal(Array.empty[Byte], 0, 0)
+
+  override def doFinal(input: Array[Byte]): Array[Byte] =
+    doFinal(input, 0, input.length)
+
+  override def doFinal(
+      input: Array[Byte],
+      inputOffset: Int,
+      inputLen: Int
+  ): Array[Byte] = {
+    require(initialized, "Cipher not initialized")
+
+    if (isGcm) doFinalGcm(input, inputOffset, inputLen)
+    else doFinalCbc(input, inputOffset, inputLen)
+  }
+
+  private def doFinalGcm(
+      input: Array[Byte],
+      inputOffset: Int,
+      inputLen: Int
+  ): Array[Byte] = {
+    // Combine accumulated data with any final input
+    val allInput =
+      if (inputLen > 0) {
+        val chunk = new Array[Byte](inputLen)
+        System.arraycopy(input, inputOffset, chunk, 0, inputLen)
+        accumulated ++ chunk
+      } else accumulated
+
+    accumulated = Array.empty
+
+    if (opmode == Cipher.ENCRYPT_MODE) {
+      // Encrypt all data
+      val maxOut = allInput.length + 16 // room for potential extra
+      val outBuf = new Array[Byte](maxOut)
+      val outl = stackalloc[CInt]()
+      var totalOut = 0
+
+      if (allInput.nonEmpty) {
+        if (
+          crypto.EVP_EncryptUpdate(
+            ctx,
+            outBuf.asInstanceOf[ByteArray].at(0),
+            outl,
+            allInput.asInstanceOf[ByteArray].at(0),
+            allInput.length
+          ) != 1
+        )
+          throw new RuntimeException("Failed to encrypt data")
+        totalOut += !outl
+      }
+
+      // Finalize
+      if (
+        crypto.EVP_EncryptFinal_ex(
+          ctx,
+          outBuf.asInstanceOf[ByteArray].at(totalOut),
+          outl
+        ) != 1
+      )
+        throw new RuntimeException("Failed to finalize encryption")
+      totalOut += !outl
+
+      // Get the auth tag
+      val tag = new Array[Byte](gcmTagLen)
+      if (
+        crypto.EVP_CIPHER_CTX_ctrl(
+          ctx,
+          EVP_CTRL_AEAD_GET_TAG,
+          gcmTagLen,
+          tag.asInstanceOf[ByteArray].at(0)
+        ) != 1
+      )
+        throw new RuntimeException("Failed to get GCM auth tag")
+
+      // Return ciphertext || tag
+      val result = new Array[Byte](totalOut + gcmTagLen)
+      System.arraycopy(outBuf, 0, result, 0, totalOut)
+      System.arraycopy(tag, 0, result, totalOut, gcmTagLen)
+      result
+
+    } else {
+      // Decrypt: input is ciphertext || tag
+      if (allInput.length < gcmTagLen)
+        throw new AEADBadTagException("Input too short for GCM tag")
+
+      val ciphertextLen = allInput.length - gcmTagLen
+      val tag = new Array[Byte](gcmTagLen)
+      System.arraycopy(allInput, ciphertextLen, tag, 0, gcmTagLen)
+
+      // Set the expected tag before decrypting
+      if (
+        crypto.EVP_CIPHER_CTX_ctrl(
+          ctx,
+          EVP_CTRL_AEAD_SET_TAG,
+          gcmTagLen,
+          tag.asInstanceOf[ByteArray].at(0)
+        ) != 1
+      )
+        throw new RuntimeException("Failed to set GCM auth tag")
+
+      val outBuf = new Array[Byte](ciphertextLen + 16)
+      val outl = stackalloc[CInt]()
+      var totalOut = 0
+
+      if (ciphertextLen > 0) {
+        if (
+          crypto.EVP_DecryptUpdate(
+            ctx,
+            outBuf.asInstanceOf[ByteArray].at(0),
+            outl,
+            allInput.asInstanceOf[ByteArray].at(0),
+            ciphertextLen
+          ) != 1
+        )
+          throw new RuntimeException("Failed to decrypt data")
+        totalOut += !outl
+      }
+
+      // Finalize — returns 0 if auth tag doesn't match
+      if (
+        crypto.EVP_DecryptFinal_ex(
+          ctx,
+          outBuf.asInstanceOf[ByteArray].at(totalOut),
+          outl
+        ) != 1
+      )
+        throw new AEADBadTagException("GCM authentication failed")
+      totalOut += !outl
+
+      val result = new Array[Byte](totalOut)
+      System.arraycopy(outBuf, 0, result, 0, totalOut)
+      result
+    }
+  }
+
+  private def doFinalCbc(
+      input: Array[Byte],
+      inputOffset: Int,
+      inputLen: Int
+  ): Array[Byte] = {
+    val outl = stackalloc[CInt]()
+    // Max output: inputLen + block size for update + block size for final
+    val maxOut = inputLen + 32
+    val outBuf = new Array[Byte](maxOut)
+    var totalOut = 0
+
+    // Process remaining input
+    if (inputLen > 0) {
+      val inPtr = input.asInstanceOf[ByteArray].at(inputOffset)
+
+      val rc =
+        if (opmode == Cipher.ENCRYPT_MODE)
+          crypto.EVP_EncryptUpdate(
+            ctx,
+            outBuf.asInstanceOf[ByteArray].at(0),
+            outl,
+            inPtr,
+            inputLen
+          )
+        else
+          crypto.EVP_DecryptUpdate(
+            ctx,
+            outBuf.asInstanceOf[ByteArray].at(0),
+            outl,
+            inPtr,
+            inputLen
+          )
+
+      if (rc != 1)
+        throw new RuntimeException("Failed to update cipher")
+      totalOut += !outl
+    }
+
+    // Finalize
+    val rc =
+      if (opmode == Cipher.ENCRYPT_MODE)
+        crypto.EVP_EncryptFinal_ex(
+          ctx,
+          outBuf.asInstanceOf[ByteArray].at(totalOut),
+          outl
+        )
+      else
+        crypto.EVP_DecryptFinal_ex(
+          ctx,
+          outBuf.asInstanceOf[ByteArray].at(totalOut),
+          outl
+        )
+
+    if (rc != 1)
+      throw new BadPaddingException("Decryption failed (bad padding)")
+    totalOut += !outl
+
+    val result = new Array[Byte](totalOut)
+    System.arraycopy(outBuf, 0, result, 0, totalOut)
+    result
+  }
+}

--- a/scala-native-crypto/src/com/github/lolgab/scalanativecrypto/internal/package.scala
+++ b/scala-native-crypto/src/com/github/lolgab/scalanativecrypto/internal/package.scala
@@ -41,10 +41,76 @@ object crypto {
 
   // Function to get the SHA-256 algorithm
   def EVP_sha256(): EVP_MD_* = extern
+
+  // -- EVP Cipher API --
+
+  type EVP_CIPHER_* = CVoidPtr
+  type EVP_CIPHER_CTX_* = CVoidPtr
+
+  def EVP_CIPHER_CTX_new(): EVP_CIPHER_CTX_* = extern
+  def EVP_CIPHER_CTX_free(ctx: EVP_CIPHER_CTX_*): Unit = extern
+  def EVP_CIPHER_CTX_reset(ctx: EVP_CIPHER_CTX_*): CInt = extern
+  def EVP_CIPHER_CTX_ctrl(
+      ctx: EVP_CIPHER_CTX_*,
+      `type`: CInt,
+      arg: CInt,
+      ptr: CVoidPtr
+  ): CInt = extern
+  def EVP_CIPHER_CTX_block_size(ctx: EVP_CIPHER_CTX_*): CInt = extern
+
+  def EVP_aes_128_gcm(): EVP_CIPHER_* = extern
+  def EVP_aes_256_gcm(): EVP_CIPHER_* = extern
+  def EVP_aes_128_cbc(): EVP_CIPHER_* = extern
+  def EVP_aes_256_cbc(): EVP_CIPHER_* = extern
+
+  def EVP_EncryptInit_ex(
+      ctx: EVP_CIPHER_CTX_*,
+      cipher: EVP_CIPHER_*,
+      impl: CVoidPtr,
+      key: Ptr[Byte],
+      iv: Ptr[Byte]
+  ): CInt = extern
+  def EVP_EncryptUpdate(
+      ctx: EVP_CIPHER_CTX_*,
+      out: Ptr[Byte],
+      outl: Ptr[CInt],
+      in: Ptr[Byte],
+      inl: CInt
+  ): CInt = extern
+  def EVP_EncryptFinal_ex(
+      ctx: EVP_CIPHER_CTX_*,
+      out: Ptr[Byte],
+      outl: Ptr[CInt]
+  ): CInt = extern
+
+  def EVP_DecryptInit_ex(
+      ctx: EVP_CIPHER_CTX_*,
+      cipher: EVP_CIPHER_*,
+      impl: CVoidPtr,
+      key: Ptr[Byte],
+      iv: Ptr[Byte]
+  ): CInt = extern
+  def EVP_DecryptUpdate(
+      ctx: EVP_CIPHER_CTX_*,
+      out: Ptr[Byte],
+      outl: Ptr[CInt],
+      in: Ptr[Byte],
+      inl: CInt
+  ): CInt = extern
+  def EVP_DecryptFinal_ex(
+      ctx: EVP_CIPHER_CTX_*,
+      out: Ptr[Byte],
+      outl: Ptr[CInt]
+  ): CInt = extern
 }
 
 object Constants {
   val EVP_MAX_MD_SIZE: Int = 64
+
+  // EVP_CIPHER_CTX_ctrl types
+  val EVP_CTRL_AEAD_SET_IVLEN: Int = 0x9
+  val EVP_CTRL_AEAD_GET_TAG: Int = 0x10
+  val EVP_CTRL_AEAD_SET_TAG: Int = 0x11
 }
 object Utils {
   def getAlgorithmNameAndLength(

--- a/scala-native-crypto/src/com/github/lolgab/scalanativecrypto/services/CipherService.scala
+++ b/scala-native-crypto/src/com/github/lolgab/scalanativecrypto/services/CipherService.scala
@@ -1,0 +1,62 @@
+package com.github.lolgab.scalanativecrypto.services
+
+import com.github.lolgab.scalanativecrypto.JcaService
+import com.github.lolgab.scalanativecrypto.crypto.OpenSslCipher
+
+import java.security.NoSuchAlgorithmException
+import java.security.Provider
+import java.util.{List => JList}
+import java.util.{Map => JMap}
+import javax.crypto.Cipher
+
+class OpenSslCipherService private (
+    private val provider: Provider,
+    private val algorithm: String,
+    private val aliases: JList[String],
+    private val attributes: JMap[String, String]
+) extends Provider.Service(
+      provider,
+      JcaService.Cipher.name,
+      algorithm,
+      "com.github.lolgab.scalanativecrypto.services.OpenSslCipherService",
+      aliases,
+      attributes
+    ) {
+
+  override def supportsParameter(parameter: Object): Boolean =
+    if (parameter == null) true
+    else false
+
+  override def newInstance(constructorParameter: Object): Cipher = {
+    // Parse transformation: "AES/GCM/NoPadding" or "AES/CBC/PKCS5Padding"
+    val parts = algorithm.split("/")
+    if (parts.length != 3)
+      throw new NoSuchAlgorithmException(
+        s"Invalid transformation: $algorithm"
+      )
+
+    val mode = parts(1).toUpperCase()
+    val padding = parts(2)
+
+    new OpenSslCipher(
+      provider,
+      algorithm,
+      mode,
+      padding
+    )
+  }
+}
+
+object OpenSslCipherService {
+  def apply(
+      provider: Provider,
+      algorithm: String,
+      aliases: JList[String],
+      attributes: JMap[String, String]
+  ): OpenSslCipherService = new OpenSslCipherService(
+    provider,
+    algorithm,
+    aliases,
+    attributes
+  )
+}

--- a/scala-native-crypto/src/java/com/github/lolgab/scalanativecrypto/internal/CtxFinalizer.scala
+++ b/scala-native-crypto/src/java/com/github/lolgab/scalanativecrypto/internal/CtxFinalizer.scala
@@ -22,4 +22,15 @@ object CtxFinalizer {
   def register_HMAC_CTX(owner: AnyRef, ctx: crypto.HMAC_CTX_*): Unit =
     cleaner.register(owner, new HMAC_CTX_State(ctx))
 
+  private final class EVP_CIPHER_CTX_State(ctx: crypto.EVP_CIPHER_CTX_*)
+      extends Runnable {
+    override def run(): Unit = crypto.EVP_CIPHER_CTX_free(ctx)
+  }
+
+  def register_EVP_CIPHER_CTX(
+      owner: AnyRef,
+      ctx: crypto.EVP_CIPHER_CTX_*
+  ): Unit =
+    cleaner.register(owner, new EVP_CIPHER_CTX_State(ctx))
+
 }

--- a/scala-native-crypto/src/javax/crypto/AEADBadTagException.scala
+++ b/scala-native-crypto/src/javax/crypto/AEADBadTagException.scala
@@ -1,0 +1,10 @@
+package javax.crypto
+
+/**
+ * Refs:
+ *
+ *   - https://docs.oracle.com/en/java/javase/25/docs/api/java.base/javax/crypto/AEADBadTagException.html
+ */
+class AEADBadTagException(msg: String) extends BadPaddingException(msg) {
+  def this() = this(null)
+}

--- a/scala-native-crypto/src/javax/crypto/BadPaddingException.scala
+++ b/scala-native-crypto/src/javax/crypto/BadPaddingException.scala
@@ -1,0 +1,12 @@
+package javax.crypto
+
+import java.security.GeneralSecurityException
+
+/**
+ * Refs:
+ *
+ *   - https://docs.oracle.com/en/java/javase/25/docs/api/java.base/javax/crypto/BadPaddingException.html
+ */
+class BadPaddingException(msg: String) extends GeneralSecurityException(msg) {
+  def this() = this(null)
+}

--- a/scala-native-crypto/src/javax/crypto/Cipher.scala
+++ b/scala-native-crypto/src/javax/crypto/Cipher.scala
@@ -132,6 +132,10 @@ abstract class Cipher protected (
 }
 
 object Cipher {
+  import com.github.lolgab.scalanativecrypto.{OpenSslProvider, JcaService}
+  import java.security.NoSuchAlgorithmException
+  import java.util.Objects.requireNonNull
+
   // magic numbers come from
   // https://docs.oracle.com/en/java/javase/25/docs/api/constant-values.html
   final val ENCRYPT_MODE: Int = 1
@@ -142,15 +146,32 @@ object Cipher {
   final val PRIVATE_KEY: Int = 2
   final val SECRET_KEY: Int = 3
 
-  def getInstance(transformation: String): Cipher = ???
+  def getInstance(transformation: String): Cipher =
+    getInstance(transformation, OpenSslProvider.defaultInstance)
 
-  def getInstance(transformation: String, provider: String): Cipher = ???
+  def getInstance(transformation: String, provider: String): Cipher =
+    throw new UnsupportedOperationException()
 
-  def getInstance(transformation: String, provider: Provider): Cipher = ???
+  def getInstance(transformation: String, provider: Provider): Cipher = {
+    requireNonNull(transformation)
+    requireNonNull(provider)
+    require(transformation.nonEmpty)
 
-  def getMaxAllowedKeyLength(transformation: String): Int = ???
+    val service = provider
+      .getService(JcaService.Cipher.name, transformation)
+    if (service == null)
+      throw new NoSuchAlgorithmException(
+        s"Cipher $transformation not found in provider ${provider.getName()}"
+      )
+
+    service
+      .newInstance(null)
+      .asInstanceOf[Cipher]
+  }
+
+  def getMaxAllowedKeyLength(transformation: String): Int = Int.MaxValue
 
   def getMaxAllowedParameterSpec(
       transformation: String
-  ): AlgorithmParameterSpec = ???
+  ): AlgorithmParameterSpec = null
 }

--- a/scala-native-crypto/src/javax/crypto/IllegalBlockSizeException.scala
+++ b/scala-native-crypto/src/javax/crypto/IllegalBlockSizeException.scala
@@ -1,0 +1,13 @@
+package javax.crypto
+
+import java.security.GeneralSecurityException
+
+/**
+ * Refs:
+ *
+ *   - https://docs.oracle.com/en/java/javase/25/docs/api/java.base/javax/crypto/IllegalBlockSizeException.html
+ */
+class IllegalBlockSizeException(msg: String)
+    extends GeneralSecurityException(msg) {
+  def this() = this(null)
+}

--- a/scala-native-crypto/src/javax/crypto/ShortBufferException.scala
+++ b/scala-native-crypto/src/javax/crypto/ShortBufferException.scala
@@ -1,0 +1,12 @@
+package javax.crypto
+
+import java.security.GeneralSecurityException
+
+/**
+ * Refs:
+ *
+ *   - https://docs.oracle.com/en/java/javase/25/docs/api/java.base/javax/crypto/ShortBufferException.html
+ */
+class ShortBufferException(msg: String) extends GeneralSecurityException(msg) {
+  def this() = this(null)
+}

--- a/scala-native-crypto/src/javax/crypto/spec/GCMParameterSpec.scala
+++ b/scala-native-crypto/src/javax/crypto/spec/GCMParameterSpec.scala
@@ -1,0 +1,36 @@
+package javax.crypto.spec
+
+import java.security.spec.AlgorithmParameterSpec
+
+/**
+ * Refs:
+ *
+ *   - https://docs.oracle.com/en/java/javase/25/docs/api/java.base/javax/crypto/spec/GCMParameterSpec.html
+ */
+class GCMParameterSpec(
+    private val tLen: Int,
+    private val src: Array[Byte],
+    private val offset: Int,
+    private val len: Int
+) extends AlgorithmParameterSpec {
+
+  if (src == null)
+    throw new IllegalArgumentException("src array is null")
+  if (tLen < 0)
+    throw new IllegalArgumentException("Invalid tag length")
+  if (offset < 0 || len < 0 || offset + len > src.length)
+    throw new ArrayIndexOutOfBoundsException("Invalid offset/length")
+
+  private val iv: Array[Byte] = {
+    val arr = new Array[Byte](len)
+    System.arraycopy(src, offset, arr, 0, len)
+    arr
+  }
+
+  def this(tLen: Int, src: Array[Byte]) =
+    this(tLen, src, 0, if (src == null) 0 else src.length)
+
+  def getTLen(): Int = tLen
+
+  def getIV(): Array[Byte] = iv.clone()
+}

--- a/scala-native-crypto/src/javax/crypto/spec/IvParameterSpec.scala
+++ b/scala-native-crypto/src/javax/crypto/spec/IvParameterSpec.scala
@@ -1,0 +1,31 @@
+package javax.crypto.spec
+
+import java.security.spec.AlgorithmParameterSpec
+
+/**
+ * Refs:
+ *
+ *   - https://docs.oracle.com/en/java/javase/25/docs/api/java.base/javax/crypto/spec/IvParameterSpec.html
+ */
+class IvParameterSpec(
+    private val src: Array[Byte],
+    private val offset: Int,
+    private val len: Int
+) extends AlgorithmParameterSpec {
+
+  if (src == null)
+    throw new IllegalArgumentException("IV array is null")
+  if (offset < 0 || len < 0 || offset + len > src.length)
+    throw new ArrayIndexOutOfBoundsException("Invalid offset/length")
+
+  private val iv: Array[Byte] = {
+    val arr = new Array[Byte](len)
+    System.arraycopy(src, offset, arr, 0, len)
+    arr
+  }
+
+  def this(iv: Array[Byte]) =
+    this(iv, 0, if (iv == null) 0 else iv.length)
+
+  def getIV(): Array[Byte] = iv.clone()
+}

--- a/tests/src/scalanativecrypto/CipherSuite.scala
+++ b/tests/src/scalanativecrypto/CipherSuite.scala
@@ -1,0 +1,508 @@
+package scalanativecrypto
+
+import utest._
+
+import java.security.SecureRandom
+import java.util.Arrays
+import javax.crypto._
+import javax.crypto.spec._
+
+object CipherSuite extends TestSuite {
+
+  private def randomBytes(n: Int): Array[Byte] = {
+    val bytes = new Array[Byte](n)
+    new SecureRandom().nextBytes(bytes)
+    bytes
+  }
+
+  private def hexEncode(bytes: Array[Byte]): String =
+    bytes.map(b => f"${b & 0xff}%02x").mkString
+
+  val tests = Tests {
+
+    // -- AES/GCM/NoPadding --
+
+    test("AES-256-GCM round-trip") {
+      val key = randomBytes(32)
+      val nonce = randomBytes(12)
+      val plaintext = "Hello, AES-GCM!".getBytes("UTF-8")
+
+      val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+      cipher.init(
+        Cipher.ENCRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new GCMParameterSpec(128, nonce)
+      )
+      val ciphertext = cipher.doFinal(plaintext)
+
+      val decipher = Cipher.getInstance("AES/GCM/NoPadding")
+      decipher.init(
+        Cipher.DECRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new GCMParameterSpec(128, nonce)
+      )
+      val decrypted = decipher.doFinal(ciphertext)
+
+      assert(Arrays.equals(decrypted, plaintext))
+    }
+
+    test("AES-128-GCM round-trip") {
+      val key = randomBytes(16)
+      val nonce = randomBytes(12)
+      val plaintext = "AES-128-GCM test".getBytes("UTF-8")
+
+      val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+      cipher.init(
+        Cipher.ENCRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new GCMParameterSpec(128, nonce)
+      )
+      val ciphertext = cipher.doFinal(plaintext)
+
+      val decipher = Cipher.getInstance("AES/GCM/NoPadding")
+      decipher.init(
+        Cipher.DECRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new GCMParameterSpec(128, nonce)
+      )
+      val decrypted = decipher.doFinal(ciphertext)
+
+      assert(Arrays.equals(decrypted, plaintext))
+    }
+
+    test("AES-GCM empty plaintext") {
+      val key = randomBytes(32)
+      val nonce = randomBytes(12)
+
+      val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+      cipher.init(
+        Cipher.ENCRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new GCMParameterSpec(128, nonce)
+      )
+      val ciphertext = cipher.doFinal(Array.empty[Byte])
+
+      // Should be just the 16-byte tag
+      assert(ciphertext.length == 16)
+
+      val decipher = Cipher.getInstance("AES/GCM/NoPadding")
+      decipher.init(
+        Cipher.DECRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new GCMParameterSpec(128, nonce)
+      )
+      val decrypted = decipher.doFinal(ciphertext)
+
+      assert(decrypted.length == 0)
+    }
+
+    test("AES-GCM large plaintext") {
+      val key = randomBytes(32)
+      val nonce = randomBytes(12)
+      val plaintext = randomBytes(10000)
+
+      val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+      cipher.init(
+        Cipher.ENCRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new GCMParameterSpec(128, nonce)
+      )
+      val ciphertext = cipher.doFinal(plaintext)
+
+      assert(ciphertext.length == plaintext.length + 16)
+
+      val decipher = Cipher.getInstance("AES/GCM/NoPadding")
+      decipher.init(
+        Cipher.DECRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new GCMParameterSpec(128, nonce)
+      )
+      val decrypted = decipher.doFinal(ciphertext)
+
+      assert(Arrays.equals(decrypted, plaintext))
+    }
+
+    test("AES-GCM with AAD") {
+      val key = randomBytes(32)
+      val nonce = randomBytes(12)
+      val plaintext = "secret data".getBytes("UTF-8")
+      val aad = "authenticated metadata".getBytes("UTF-8")
+
+      val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+      cipher.init(
+        Cipher.ENCRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new GCMParameterSpec(128, nonce)
+      )
+      cipher.updateAAD(aad)
+      val ciphertext = cipher.doFinal(plaintext)
+
+      val decipher = Cipher.getInstance("AES/GCM/NoPadding")
+      decipher.init(
+        Cipher.DECRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new GCMParameterSpec(128, nonce)
+      )
+      decipher.updateAAD(aad)
+      val decrypted = decipher.doFinal(ciphertext)
+
+      assert(Arrays.equals(decrypted, plaintext))
+    }
+
+    test("AES-GCM deterministic with same key and nonce") {
+      val key = randomBytes(32)
+      val nonce = randomBytes(12)
+      val plaintext = "test".getBytes("UTF-8")
+
+      val cipher1 = Cipher.getInstance("AES/GCM/NoPadding")
+      cipher1.init(
+        Cipher.ENCRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new GCMParameterSpec(128, nonce)
+      )
+      val ct1 = cipher1.doFinal(plaintext)
+
+      val cipher2 = Cipher.getInstance("AES/GCM/NoPadding")
+      cipher2.init(
+        Cipher.ENCRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new GCMParameterSpec(128, nonce)
+      )
+      val ct2 = cipher2.doFinal(plaintext)
+
+      assert(Arrays.equals(ct1, ct2))
+    }
+
+    test("AES-GCM wrong key fails") {
+      val key = randomBytes(32)
+      val wrongKey = randomBytes(32)
+      val nonce = randomBytes(12)
+      val plaintext = "secret".getBytes("UTF-8")
+
+      val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+      cipher.init(
+        Cipher.ENCRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new GCMParameterSpec(128, nonce)
+      )
+      val ciphertext = cipher.doFinal(plaintext)
+
+      val decipher = Cipher.getInstance("AES/GCM/NoPadding")
+      decipher.init(
+        Cipher.DECRYPT_MODE,
+        new SecretKeySpec(wrongKey, "AES"),
+        new GCMParameterSpec(128, nonce)
+      )
+
+      assertThrows[AEADBadTagException] {
+        decipher.doFinal(ciphertext)
+      }
+    }
+
+    test("AES-GCM tampered ciphertext fails") {
+      val key = randomBytes(32)
+      val nonce = randomBytes(12)
+      val plaintext = "secret".getBytes("UTF-8")
+
+      val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+      cipher.init(
+        Cipher.ENCRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new GCMParameterSpec(128, nonce)
+      )
+      val ciphertext = cipher.doFinal(plaintext)
+
+      // Tamper with the last byte (tag)
+      ciphertext(ciphertext.length - 1) =
+        (ciphertext(ciphertext.length - 1) ^ 0xff).toByte
+
+      val decipher = Cipher.getInstance("AES/GCM/NoPadding")
+      decipher.init(
+        Cipher.DECRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new GCMParameterSpec(128, nonce)
+      )
+
+      assertThrows[AEADBadTagException] {
+        decipher.doFinal(ciphertext)
+      }
+    }
+
+    test("AES-GCM wrong AAD fails") {
+      val key = randomBytes(32)
+      val nonce = randomBytes(12)
+      val plaintext = "secret".getBytes("UTF-8")
+
+      val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+      cipher.init(
+        Cipher.ENCRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new GCMParameterSpec(128, nonce)
+      )
+      cipher.updateAAD("correct".getBytes("UTF-8"))
+      val ciphertext = cipher.doFinal(plaintext)
+
+      val decipher = Cipher.getInstance("AES/GCM/NoPadding")
+      decipher.init(
+        Cipher.DECRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new GCMParameterSpec(128, nonce)
+      )
+      decipher.updateAAD("wrong".getBytes("UTF-8"))
+
+      assertThrows[AEADBadTagException] {
+        decipher.doFinal(ciphertext)
+      }
+    }
+
+    // -- AES/CBC/PKCS5Padding --
+
+    test("AES-256-CBC round-trip") {
+      val key = randomBytes(32)
+      val iv = randomBytes(16)
+      val plaintext = "Hello, AES-CBC!".getBytes("UTF-8")
+
+      val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+      cipher.init(
+        Cipher.ENCRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new IvParameterSpec(iv)
+      )
+      val ciphertext = cipher.doFinal(plaintext)
+
+      val decipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+      decipher.init(
+        Cipher.DECRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new IvParameterSpec(iv)
+      )
+      val decrypted = decipher.doFinal(ciphertext)
+
+      assert(Arrays.equals(decrypted, plaintext))
+    }
+
+    test("AES-128-CBC round-trip") {
+      val key = randomBytes(16)
+      val iv = randomBytes(16)
+      val plaintext = "AES-128-CBC test".getBytes("UTF-8")
+
+      val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+      cipher.init(
+        Cipher.ENCRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new IvParameterSpec(iv)
+      )
+      val ciphertext = cipher.doFinal(plaintext)
+
+      val decipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+      decipher.init(
+        Cipher.DECRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new IvParameterSpec(iv)
+      )
+      val decrypted = decipher.doFinal(ciphertext)
+
+      assert(Arrays.equals(decrypted, plaintext))
+    }
+
+    test("AES-CBC empty plaintext") {
+      val key = randomBytes(32)
+      val iv = randomBytes(16)
+
+      val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+      cipher.init(
+        Cipher.ENCRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new IvParameterSpec(iv)
+      )
+      val ciphertext = cipher.doFinal(Array.empty[Byte])
+
+      // PKCS7 padding adds a full block for empty input
+      assert(ciphertext.length == 16)
+
+      val decipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+      decipher.init(
+        Cipher.DECRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new IvParameterSpec(iv)
+      )
+      val decrypted = decipher.doFinal(ciphertext)
+
+      assert(decrypted.length == 0)
+    }
+
+    test("AES-CBC block-aligned plaintext") {
+      val key = randomBytes(32)
+      val iv = randomBytes(16)
+      val plaintext = new Array[Byte](48) // 3 blocks
+      Arrays.fill(plaintext, 0x42.toByte)
+
+      val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+      cipher.init(
+        Cipher.ENCRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new IvParameterSpec(iv)
+      )
+      val ciphertext = cipher.doFinal(plaintext)
+
+      // Block-aligned + PKCS7 adds one full padding block
+      assert(ciphertext.length == 64)
+
+      val decipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+      decipher.init(
+        Cipher.DECRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new IvParameterSpec(iv)
+      )
+      val decrypted = decipher.doFinal(ciphertext)
+
+      assert(Arrays.equals(decrypted, plaintext))
+    }
+
+    test("AES-CBC non-block-aligned plaintext") {
+      val key = randomBytes(32)
+      val iv = randomBytes(16)
+      val plaintext = new Array[Byte](37)
+      Arrays.fill(plaintext, 0xcd.toByte)
+
+      val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+      cipher.init(
+        Cipher.ENCRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new IvParameterSpec(iv)
+      )
+      val ciphertext = cipher.doFinal(plaintext)
+
+      val decipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+      decipher.init(
+        Cipher.DECRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new IvParameterSpec(iv)
+      )
+      val decrypted = decipher.doFinal(ciphertext)
+
+      assert(Arrays.equals(decrypted, plaintext))
+    }
+
+    test("AES-CBC deterministic with same key and IV") {
+      val key = randomBytes(32)
+      val iv = randomBytes(16)
+      val plaintext = "test".getBytes("UTF-8")
+
+      val cipher1 = Cipher.getInstance("AES/CBC/PKCS5Padding")
+      cipher1.init(
+        Cipher.ENCRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new IvParameterSpec(iv)
+      )
+      val ct1 = cipher1.doFinal(plaintext)
+
+      val cipher2 = Cipher.getInstance("AES/CBC/PKCS5Padding")
+      cipher2.init(
+        Cipher.ENCRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new IvParameterSpec(iv)
+      )
+      val ct2 = cipher2.doFinal(plaintext)
+
+      assert(Arrays.equals(ct1, ct2))
+    }
+
+    test("AES-CBC wrong key fails") {
+      val key = randomBytes(32)
+      val wrongKey = randomBytes(32)
+      val iv = randomBytes(16)
+      val plaintext = "secret".getBytes("UTF-8")
+
+      val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+      cipher.init(
+        Cipher.ENCRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new IvParameterSpec(iv)
+      )
+      val ciphertext = cipher.doFinal(plaintext)
+
+      val decipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+      decipher.init(
+        Cipher.DECRYPT_MODE,
+        new SecretKeySpec(wrongKey, "AES"),
+        new IvParameterSpec(iv)
+      )
+
+      assertThrows[BadPaddingException] {
+        decipher.doFinal(ciphertext)
+      }
+    }
+
+    // -- GCM with update() --
+
+    test("AES-GCM using update then doFinal") {
+      val key = randomBytes(32)
+      val nonce = randomBytes(12)
+      val plaintext = "Hello, World! This is a longer message.".getBytes("UTF-8")
+
+      val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+      cipher.init(
+        Cipher.ENCRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new GCMParameterSpec(128, nonce)
+      )
+      val updateOut = cipher.update(plaintext)
+      val finalOut = cipher.doFinal()
+
+      // Combine update + final output
+      val ciphertext = updateOut ++ finalOut
+
+      assert(ciphertext.length == plaintext.length + 16)
+
+      val decipher = Cipher.getInstance("AES/GCM/NoPadding")
+      decipher.init(
+        Cipher.DECRYPT_MODE,
+        new SecretKeySpec(key, "AES"),
+        new GCMParameterSpec(128, nonce)
+      )
+      val decUpdateOut = decipher.update(ciphertext)
+      val decFinalOut = decipher.doFinal()
+
+      val decrypted = decUpdateOut ++ decFinalOut
+
+      assert(Arrays.equals(decrypted, plaintext))
+    }
+
+    // -- Spec classes --
+
+    test("GCMParameterSpec stores IV correctly") {
+      val iv = Array[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
+      val spec = new GCMParameterSpec(128, iv)
+      assert(spec.getTLen() == 128)
+      assert(Arrays.equals(spec.getIV(), iv))
+
+      // Modifying original should not affect spec
+      iv(0) = 0
+      assert(spec.getIV()(0) == 1)
+    }
+
+    test("IvParameterSpec stores IV correctly") {
+      val iv =
+        Array[Byte](1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
+      val spec = new IvParameterSpec(iv)
+      assert(Arrays.equals(spec.getIV(), iv))
+
+      // Modifying original should not affect spec
+      iv(0) = 0
+      assert(spec.getIV()(0) == 1)
+    }
+
+    test("GCMParameterSpec rejects null") {
+      assertThrows[IllegalArgumentException] {
+        new GCMParameterSpec(128, null)
+      }
+    }
+
+    test("IvParameterSpec rejects null") {
+      assertThrows[Exception] {
+        new IvParameterSpec(null)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Implement `Cipher` using OpenSSL's EVP API, supporting `AES/GCM/NoPadding` and `AES/CBC/PKCS5Padding` with 128-bit and 256-bit keys
- Wire `Cipher.getInstance()` to `OpenSslProvider` (was stubbed with `???`)
- Add missing `javax.crypto.spec` and exception classes needed for cipher operations

## New classes

**Implementation:**
- `OpenSslCipher` — EVP-backed Cipher implementation with GCM (AEAD) and CBC (PKCS7 padding) support
- `OpenSslCipherService` — provider service for cipher registration

**javax.crypto.spec:**
- `GCMParameterSpec` — GCM nonce and tag length parameter
- `IvParameterSpec` — CBC initialization vector parameter

**Exceptions:**
- `BadPaddingException`, `AEADBadTagException`, `ShortBufferException`, `IllegalBlockSizeException`

## Changes to existing files

- `internal/package.scala` — added EVP cipher C bindings (`EVP_CIPHER_CTX_*`, `EVP_EncryptInit_ex`, `EVP_DecryptInit_ex`, etc.)
- `CtxFinalizer.scala` — added `register_EVP_CIPHER_CTX` for OpenSSL context cleanup
- `OpenSslProvider.scala` — registered `AES/GCM/NoPadding` and `AES/CBC/PKCS5Padding` services
- `Cipher.scala` — wired `getInstance()` to the provider dispatch

## Tests

21 new tests in `CipherSuite.scala` covering:
- GCM and CBC round-trips (128-bit and 256-bit keys)
- Empty, large (10 KB), block-aligned, and non-block-aligned payloads
- AAD (Additional Authenticated Data) for GCM
- Deterministic encryption with same key/nonce
- Authentication failure: wrong key, tampered ciphertext, wrong AAD
- `update()` + `doFinal()` streaming pattern
- `GCMParameterSpec` and `IvParameterSpec` validation

All 52 tests (31 existing + 21 new) pass on both JVM and Native.

## Test plan

- [x] `mill 'tests.native[3.3.7].test'` — 52 passed
- [x] `mill 'tests.jvm[3.3.7].test'` — 52 passed