### PR TITLE
feat: Implement Ed25519 signature and key generation via OpenSSL EVP API

### DIFF
--- a/scala-native-crypto/src/com/github/lolgab/scalanativecrypto/OpenSslProvider.scala
+++ b/scala-native-crypto/src/com/github/lolgab/scalanativecrypto/OpenSslProvider.scala
@@ -115,6 +115,20 @@ class OpenSslProvider(
         aliases.forEach(alias => putAliasService(svc, alias))
       }
 
+      // Ed25519 Signature
+      {
+        val svc = OpenSslSignatureService(this, "Ed25519", JList.of("EdDSA"), JMap.of())
+        putService(svc)
+        putAliasService(svc, "EdDSA")
+      }
+
+      // Ed25519 KeyPairGenerator
+      {
+        val svc = OpenSslKeyPairGeneratorService(this, "Ed25519", JList.of("EdDSA"), JMap.of())
+        putService(svc)
+        putAliasService(svc, "EdDSA")
+      }
+
     }
   }
 }

--- a/scala-native-crypto/src/com/github/lolgab/scalanativecrypto/crypto/KeyPairGenerator.scala
+++ b/scala-native-crypto/src/com/github/lolgab/scalanativecrypto/crypto/KeyPairGenerator.scala
@@ -1,0 +1,46 @@
+package com.github.lolgab.scalanativecrypto.crypto
+
+import com.github.lolgab.scalanativecrypto.internal.crypto
+import com.github.lolgab.scalanativecrypto.internal.crypto._
+
+import java.com.github.lolgab.scalanativecrypto.internal.CtxFinalizer
+import java.security._
+import java.security.spec.AlgorithmParameterSpec
+
+import scala.scalanative.unsafe._
+
+/** OpenSSL-backed Ed25519 key pair generator. */
+class OpenSslEd25519KeyPairGenerator(provider: Provider)
+    extends KeyPairGenerator(new KeyPairGeneratorSpi {}, provider, "Ed25519") {
+
+  private val EVP_PKEY_ED25519 = 1087
+
+  override def initialize(keysize: Int): Unit = ()
+  override def initialize(keysize: Int, random: SecureRandom): Unit = ()
+  override def initialize(param: AlgorithmParameterSpec): Unit = ()
+  override def initialize(param: AlgorithmParameterSpec, random: SecureRandom): Unit = ()
+
+  override def generateKeyPair(): KeyPair = {
+    val ctx = crypto.EVP_PKEY_CTX_new_id(EVP_PKEY_ED25519, null)
+    if (ctx == null) throw new ProviderException("EVP_PKEY_CTX_new_id failed for Ed25519")
+
+    try {
+      if (crypto.EVP_PKEY_keygen_init(ctx) != 1)
+        throw new ProviderException("EVP_PKEY_keygen_init failed")
+
+      val pkeyPtr = stackalloc[EVP_PKEY_*]()
+      !pkeyPtr = null
+      if (crypto.EVP_PKEY_keygen(ctx, pkeyPtr) != 1)
+        throw new ProviderException("EVP_PKEY_keygen failed for Ed25519")
+
+      val pkey = !pkeyPtr
+      val pubKey = new OpenSslEd25519PublicKey(pkey)
+      val privKey = new OpenSslEd25519PrivateKey(pkey)
+      CtxFinalizer.register_EVP_PKEY(pubKey, pkey)
+
+      new KeyPair(pubKey, privKey)
+    } finally {
+      crypto.EVP_PKEY_CTX_free(ctx)
+    }
+  }
+}

--- a/scala-native-crypto/src/com/github/lolgab/scalanativecrypto/crypto/Signature.scala
+++ b/scala-native-crypto/src/com/github/lolgab/scalanativecrypto/crypto/Signature.scala
@@ -1,0 +1,211 @@
+package com.github.lolgab.scalanativecrypto.crypto
+
+import com.github.lolgab.scalanativecrypto.internal.crypto
+import com.github.lolgab.scalanativecrypto.internal.crypto._
+
+import java.com.github.lolgab.scalanativecrypto.internal.CtxFinalizer
+import java.nio.ByteBuffer
+import java.security._
+import java.security.cert.Certificate
+import java.security.spec.AlgorithmParameterSpec
+
+import scala.scalanative.runtime.ByteArray
+import scala.scalanative.unsafe._
+import scala.scalanative.unsigned._
+
+/** OpenSSL-backed Ed25519 signature implementation. */
+class OpenSslEd25519Signature(provider: Provider)
+    extends Signature(new SignatureSpi {}, provider, "Ed25519") {
+
+  private val ED25519_SIG_SIZE = 64
+  private val EVP_PKEY_ED25519 = 1087
+
+  private var pkey: EVP_PKEY_* = null
+  private val dataBuffer = new java.io.ByteArrayOutputStream()
+
+  override def initVerify(publicKey: PublicKey): Unit = {
+    if (publicKey == null) throw new InvalidKeyException("Public key is null")
+    publicKey match {
+      case k: OpenSslEd25519PublicKey =>
+        pkey = k.evpPkey
+        state = VERIFY
+        dataBuffer.reset()
+      case _ =>
+        throw new InvalidKeyException(
+          s"Unsupported key type: ${publicKey.getClass.getName}"
+        )
+    }
+  }
+
+  override def initVerify(certificate: Certificate): Unit =
+    throw new UnsupportedOperationException("Certificate-based verification not supported")
+
+  override def initSign(privateKey: PrivateKey): Unit = {
+    if (privateKey == null) throw new InvalidKeyException("Private key is null")
+    privateKey match {
+      case k: OpenSslEd25519PrivateKey =>
+        pkey = k.evpPkey
+        state = SIGN
+        dataBuffer.reset()
+      case _ =>
+        throw new InvalidKeyException(
+          s"Unsupported key type: ${privateKey.getClass.getName}"
+        )
+    }
+  }
+
+  override def initSign(privateKey: PrivateKey, random: SecureRandom): Unit =
+    initSign(privateKey)
+
+  override def update(b: Byte): Unit = {
+    if (state == UNINITIALIZED)
+      throw new SignatureException("Signature not initialized")
+    dataBuffer.write(b.toInt)
+  }
+
+  override def update(data: Array[Byte], off: Int, len: Int): Unit = {
+    if (state == UNINITIALIZED)
+      throw new SignatureException("Signature not initialized")
+    dataBuffer.write(data, off, len)
+  }
+
+  override def update(data: ByteBuffer): Unit = {
+    if (state == UNINITIALIZED)
+      throw new SignatureException("Signature not initialized")
+    if (data.hasArray) {
+      dataBuffer.write(data.array(), data.position(), data.remaining())
+      data.position(data.limit())
+    } else {
+      val bytes = new Array[Byte](data.remaining())
+      data.get(bytes)
+      dataBuffer.write(bytes)
+    }
+  }
+
+  override def sign(): Array[Byte] = {
+    if (state != SIGN)
+      throw new SignatureException("Signature not initialized for signing")
+
+    val data = dataBuffer.toByteArray
+    dataBuffer.reset()
+
+    val mdCtx = crypto.EVP_MD_CTX_new()
+    if (mdCtx == null) throw new SignatureException("Failed to create EVP_MD_CTX")
+
+    try {
+      val nullPctx: Ptr[EVP_PKEY_CTX_*] = null
+      val nullMd: EVP_MD_* = null
+      val nullEngine: ENGINE_* = null
+
+      if (crypto.EVP_DigestSignInit(mdCtx, nullPctx, nullMd, nullEngine, pkey) != 1)
+        throw new SignatureException("EVP_DigestSignInit failed")
+
+      val sigLen = stackalloc[CSize]()
+      !sigLen = ED25519_SIG_SIZE.toCSize
+      val sigBuf = stackalloc[Byte](ED25519_SIG_SIZE)
+
+      val dataPtr = if (data.isEmpty) null else data.asInstanceOf[ByteArray].at(0)
+      if (crypto.EVP_DigestSign(mdCtx, sigBuf, sigLen, dataPtr, data.length.toCSize) != 1)
+        throw new SignatureException("EVP_DigestSign failed")
+
+      val result = new Array[Byte]((!sigLen).toInt)
+      var i = 0
+      while (i < result.length) {
+        result(i) = sigBuf(i)
+        i += 1
+      }
+      result
+    } finally {
+      crypto.EVP_MD_CTX_free(mdCtx)
+    }
+  }
+
+  override def sign(outbuf: Array[Byte], off: Int, len: Int): Int = {
+    val sig = sign()
+    if (len < sig.length)
+      throw new SignatureException(s"Buffer too small: need ${sig.length}, got $len")
+    System.arraycopy(sig, 0, outbuf, off, sig.length)
+    sig.length
+  }
+
+  override def verify(sig: Array[Byte]): Boolean = {
+    if (state != VERIFY)
+      throw new SignatureException("Signature not initialized for verification")
+
+    val data = dataBuffer.toByteArray
+    dataBuffer.reset()
+
+    val mdCtx = crypto.EVP_MD_CTX_new()
+    if (mdCtx == null) throw new SignatureException("Failed to create EVP_MD_CTX")
+
+    try {
+      val nullPctx: Ptr[EVP_PKEY_CTX_*] = null
+      val nullMd: EVP_MD_* = null
+      val nullEngine: ENGINE_* = null
+
+      if (crypto.EVP_DigestVerifyInit(mdCtx, nullPctx, nullMd, nullEngine, pkey) != 1)
+        throw new SignatureException("EVP_DigestVerifyInit failed")
+
+      val sigPtr = sig.asInstanceOf[ByteArray].at(0)
+      val dataPtr = if (data.isEmpty) null else data.asInstanceOf[ByteArray].at(0)
+      crypto.EVP_DigestVerify(mdCtx, sigPtr, sig.length.toCSize, dataPtr, data.length.toCSize) == 1
+    } finally {
+      crypto.EVP_MD_CTX_free(mdCtx)
+    }
+  }
+
+  override def verify(sig: Array[Byte], off: Int, len: Int): Boolean = {
+    val subSig = new Array[Byte](len)
+    System.arraycopy(sig, off, subSig, 0, len)
+    verify(subSig)
+  }
+
+  override def setParameter(params: AlgorithmParameterSpec): Unit =
+    throw new UnsupportedOperationException("Ed25519 does not use parameters")
+
+  override def getParameters(): AlgorithmParameters = null
+}
+
+/** Ed25519 public key backed by an OpenSSL EVP_PKEY. */
+class OpenSslEd25519PublicKey(private[crypto] val evpPkey: EVP_PKEY_*) extends PublicKey {
+
+  override def getAlgorithm(): String = "Ed25519"
+  override def getFormat(): String = "RAW"
+
+  override def getEncoded(): Array[Byte] = {
+    val len = stackalloc[CSize]()
+    !len = 32.toCSize
+    val buf = stackalloc[Byte](32)
+    if (crypto.EVP_PKEY_get_raw_public_key(evpPkey, buf, len) != 1)
+      throw new java.security.spec.InvalidKeySpecException("Failed to export public key")
+    val result = new Array[Byte]((!len).toInt)
+    var i = 0
+    while (i < result.length) {
+      result(i) = buf(i)
+      i += 1
+    }
+    result
+  }
+}
+
+/** Ed25519 private key backed by an OpenSSL EVP_PKEY. */
+class OpenSslEd25519PrivateKey(private[crypto] val evpPkey: EVP_PKEY_*) extends PrivateKey {
+
+  override def getAlgorithm(): String = "Ed25519"
+  override def getFormat(): String = "RAW"
+
+  override def getEncoded(): Array[Byte] = {
+    val len = stackalloc[CSize]()
+    !len = 32.toCSize
+    val buf = stackalloc[Byte](32)
+    if (crypto.EVP_PKEY_get_raw_private_key(evpPkey, buf, len) != 1)
+      throw new java.security.spec.InvalidKeySpecException("Failed to export private key")
+    val result = new Array[Byte]((!len).toInt)
+    var i = 0
+    while (i < result.length) {
+      result(i) = buf(i)
+      i += 1
+    }
+    result
+  }
+}

--- a/scala-native-crypto/src/com/github/lolgab/scalanativecrypto/internal/package.scala
+++ b/scala-native-crypto/src/com/github/lolgab/scalanativecrypto/internal/package.scala
@@ -41,6 +41,31 @@ object crypto {
 
   // Function to get the SHA-256 algorithm
   def EVP_sha256(): EVP_MD_* = extern
+
+  // --- EVP_PKEY for Ed25519 ---
+  type EVP_PKEY_* = CVoidPtr
+  type EVP_PKEY_CTX_* = CVoidPtr
+  type ENGINE_* = CVoidPtr
+
+  def EVP_PKEY_new(): EVP_PKEY_* = extern
+  def EVP_PKEY_free(pkey: EVP_PKEY_*): Unit = extern
+
+  def EVP_PKEY_CTX_new_id(id: CInt, e: ENGINE_*): EVP_PKEY_CTX_* = extern
+  def EVP_PKEY_CTX_free(ctx: EVP_PKEY_CTX_*): Unit = extern
+  def EVP_PKEY_keygen_init(ctx: EVP_PKEY_CTX_*): CInt = extern
+  def EVP_PKEY_keygen(ctx: EVP_PKEY_CTX_*, ppkey: Ptr[EVP_PKEY_*]): CInt = extern
+
+  // Signing/verification via DigestSign API (used for Ed25519)
+  def EVP_DigestSignInit(ctx: EVP_MD_CTX_*, pctx: Ptr[EVP_PKEY_CTX_*], tpe: EVP_MD_*, e: ENGINE_*, pkey: EVP_PKEY_*): CInt = extern
+  def EVP_DigestSign(ctx: EVP_MD_CTX_*, sig: Ptr[Byte], siglen: Ptr[CSize], tbs: Ptr[Byte], tbslen: CSize): CInt = extern
+  def EVP_DigestVerifyInit(ctx: EVP_MD_CTX_*, pctx: Ptr[EVP_PKEY_CTX_*], tpe: EVP_MD_*, e: ENGINE_*, pkey: EVP_PKEY_*): CInt = extern
+  def EVP_DigestVerify(ctx: EVP_MD_CTX_*, sig: Ptr[Byte], siglen: CSize, tbs: Ptr[Byte], tbslen: CSize): CInt = extern
+
+  // Key import/export (raw format for Ed25519: 32 bytes pub, 64 bytes priv)
+  def EVP_PKEY_new_raw_public_key(tpe: CInt, e: ENGINE_*, key: Ptr[Byte], keylen: CSize): EVP_PKEY_* = extern
+  def EVP_PKEY_new_raw_private_key(tpe: CInt, e: ENGINE_*, key: Ptr[Byte], keylen: CSize): EVP_PKEY_* = extern
+  def EVP_PKEY_get_raw_public_key(pkey: EVP_PKEY_*, pub: Ptr[Byte], len: Ptr[CSize]): CInt = extern
+  def EVP_PKEY_get_raw_private_key(pkey: EVP_PKEY_*, priv: Ptr[Byte], len: Ptr[CSize]): CInt = extern
 }
 
 object Constants {

--- a/scala-native-crypto/src/com/github/lolgab/scalanativecrypto/services/KeyPairGeneratorService.scala
+++ b/scala-native-crypto/src/com/github/lolgab/scalanativecrypto/services/KeyPairGeneratorService.scala
@@ -1,0 +1,24 @@
+package com.github.lolgab.scalanativecrypto.services
+
+import com.github.lolgab.scalanativecrypto.crypto.OpenSslEd25519KeyPairGenerator
+
+import java.security.Provider
+import java.util.{List => JList, Map => JMap}
+
+class OpenSslKeyPairGeneratorService(
+    provider: Provider,
+    algorithm: String,
+    aliases: JList[String],
+    attributes: JMap[String, String]
+) extends Provider.Service(provider, "KeyPairGenerator", algorithm, "", aliases, attributes) {
+
+  override def newInstance(constructorParameter: Object): Object = {
+    algorithm match {
+      case "Ed25519" | "EdDSA" => new OpenSslEd25519KeyPairGenerator(provider)
+      case _ =>
+        throw new java.security.NoSuchAlgorithmException(
+          s"Unsupported key pair generator algorithm: $algorithm"
+        )
+    }
+  }
+}

--- a/scala-native-crypto/src/com/github/lolgab/scalanativecrypto/services/SignatureService.scala
+++ b/scala-native-crypto/src/com/github/lolgab/scalanativecrypto/services/SignatureService.scala
@@ -1,0 +1,24 @@
+package com.github.lolgab.scalanativecrypto.services
+
+import com.github.lolgab.scalanativecrypto.crypto.OpenSslEd25519Signature
+
+import java.security.Provider
+import java.util.{List => JList, Map => JMap}
+
+class OpenSslSignatureService(
+    provider: Provider,
+    algorithm: String,
+    aliases: JList[String],
+    attributes: JMap[String, String]
+) extends Provider.Service(provider, "Signature", algorithm, "", aliases, attributes) {
+
+  override def newInstance(constructorParameter: Object): Object = {
+    algorithm match {
+      case "Ed25519" | "EdDSA" => new OpenSslEd25519Signature(provider)
+      case _ =>
+        throw new java.security.NoSuchAlgorithmException(
+          s"Unsupported signature algorithm: $algorithm"
+        )
+    }
+  }
+}

--- a/scala-native-crypto/src/java/com/github/lolgab/scalanativecrypto/internal/CtxFinalizer.scala
+++ b/scala-native-crypto/src/java/com/github/lolgab/scalanativecrypto/internal/CtxFinalizer.scala
@@ -22,4 +22,11 @@ object CtxFinalizer {
   def register_HMAC_CTX(owner: AnyRef, ctx: crypto.HMAC_CTX_*): Unit =
     cleaner.register(owner, new HMAC_CTX_State(ctx))
 
+  private final class EVP_PKEY_State(pkey: crypto.EVP_PKEY_*) extends Runnable {
+    override def run(): Unit = crypto.EVP_PKEY_free(pkey)
+  }
+
+  def register_EVP_PKEY(owner: AnyRef, pkey: crypto.EVP_PKEY_*): Unit =
+    cleaner.register(owner, new EVP_PKEY_State(pkey))
+
 }

--- a/scala-native-crypto/src/java/security/KeyPairGenerator.scala
+++ b/scala-native-crypto/src/java/security/KeyPairGenerator.scala
@@ -4,6 +4,8 @@ import java.security.Provider
 import java.security.SecureRandom
 import java.security.spec.AlgorithmParameterSpec
 
+import com.github.lolgab.scalanativecrypto.OpenSslProvider
+
 abstract class KeyPairGeneratorSpi {}
 
 /**
@@ -40,11 +42,22 @@ abstract class KeyPairGenerator(
 
 object KeyPairGenerator {
 
-  def getInstance(algorithm: String): KeyPairGenerator = ???
+  def getInstance(algorithm: String): KeyPairGenerator = {
+    val provider = OpenSslProvider.defaultInstance
+    val service = provider.getService("KeyPairGenerator", algorithm)
+    if (service == null)
+      throw new NoSuchAlgorithmException(s"$algorithm KeyPairGenerator not available")
+    service.newInstance(null).asInstanceOf[KeyPairGenerator]
+  }
 
-  def getInstance(algorithm: String, provider: String): KeyPairGenerator =
+  def getInstance(algorithm: String, providerName: String): KeyPairGenerator =
     throw new UnsupportedOperationException()
 
-  def getInstance(algorithm: String, provider: Provider): KeyPairGenerator = ???
+  def getInstance(algorithm: String, provider: Provider): KeyPairGenerator = {
+    val service = provider.getService("KeyPairGenerator", algorithm)
+    if (service == null)
+      throw new NoSuchAlgorithmException(s"$algorithm KeyPairGenerator not available")
+    service.newInstance(null).asInstanceOf[KeyPairGenerator]
+  }
 
 }

--- a/scala-native-crypto/src/java/security/Signature.scala
+++ b/scala-native-crypto/src/java/security/Signature.scala
@@ -6,6 +6,8 @@ import java.security.cert.Certificate
 import java.security.spec.AlgorithmParameterSpec
 import java.util.Objects.requireNonNull
 
+import com.github.lolgab.scalanativecrypto.OpenSslProvider
+
 abstract class SignatureSpi {}
 
 /**
@@ -82,10 +84,14 @@ object Signature {
     requireNonNull(algorithm)
     require(algorithm.nonEmpty)
 
-    ???
+    val provider = OpenSslProvider.defaultInstance
+    val service = provider.getService("Signature", algorithm)
+    if (service == null)
+      throw new NoSuchAlgorithmException(s"$algorithm Signature not available")
+    service.newInstance(null).asInstanceOf[Signature]
   }
 
-  def getInstance(algorithm: String, provider: String): Signature =
+  def getInstance(algorithm: String, providerName: String): Signature =
     throw new UnsupportedOperationException()
 
   def getInstance(algorithm: String, provider: Provider): Signature = {
@@ -93,7 +99,10 @@ object Signature {
     requireNonNull(provider)
     require(algorithm.nonEmpty)
 
-    ???
+    val service = provider.getService("Signature", algorithm)
+    if (service == null)
+      throw new NoSuchAlgorithmException(s"$algorithm Signature not available")
+    service.newInstance(null).asInstanceOf[Signature]
   }
 
 }

--- a/tests/src/scalanativecrypto/Ed25519Suite.scala
+++ b/tests/src/scalanativecrypto/Ed25519Suite.scala
@@ -1,0 +1,282 @@
+package scalanativecrypto
+
+import utest._
+import java.security._
+
+/**
+ * Tests for Ed25519 signature generation and verification via
+ * java.security.Signature and java.security.KeyPairGenerator.
+ */
+object Ed25519Suite extends TestSuite {
+
+  // Helper to compare byte arrays without utest dumping them on failure
+  private def arraysEqual(a: Array[Byte], b: Array[Byte]): Boolean =
+    a.length == b.length && a.indices.forall(i => a(i) == b(i))
+
+  val tests = Tests {
+    test("KeyPairGenerator") {
+      test("getInstance returns Ed25519 generator") {
+        val kpg = KeyPairGenerator.getInstance("Ed25519")
+        val algo = kpg.getAlgorithm()
+        assert(algo == "Ed25519" || algo == "EdDSA")
+      }
+
+      test("generates a key pair") {
+        val kpg = KeyPairGenerator.getInstance("Ed25519")
+        val kp = kpg.generateKeyPair()
+        assert(kp.getPublic() != null)
+        assert(kp.getPrivate() != null)
+        val algo = kp.getPublic().getAlgorithm()
+        assert(algo == "Ed25519" || algo == "EdDSA")
+        assert(kp.getPublic().getEncoded().length >= 32)
+        assert(kp.getPrivate().getEncoded().length >= 32)
+      }
+
+      test("generates different key pairs each time") {
+        val kpg = KeyPairGenerator.getInstance("Ed25519")
+        val kp1 = kpg.generateKeyPair()
+        val kp2 = kpg.generateKeyPair()
+        val different = !arraysEqual(kp1.getPublic().getEncoded(), kp2.getPublic().getEncoded())
+        assert(different)
+      }
+
+      test("EdDSA alias works") {
+        val kpg = KeyPairGenerator.getInstance("EdDSA")
+        val algo = kpg.getAlgorithm()
+        assert(algo == "Ed25519" || algo == "EdDSA")
+      }
+    }
+
+    test("Signature") {
+      test("sign and verify roundtrip") {
+        val kpg = KeyPairGenerator.getInstance("Ed25519")
+        val kp = kpg.generateKeyPair()
+        val data = "hello world".getBytes("UTF-8")
+
+        val signer = Signature.getInstance("Ed25519")
+        signer.initSign(kp.getPrivate())
+        signer.update(data)
+        val sig = signer.sign()
+        assert(sig.length == 64)
+
+        val verifier = Signature.getInstance("Ed25519")
+        verifier.initVerify(kp.getPublic())
+        verifier.update(data)
+        assert(verifier.verify(sig))
+      }
+
+      test("verify fails with wrong public key") {
+        val kpg = KeyPairGenerator.getInstance("Ed25519")
+        val kp1 = kpg.generateKeyPair()
+        val kp2 = kpg.generateKeyPair()
+        val data = "test data".getBytes("UTF-8")
+
+        val signer = Signature.getInstance("Ed25519")
+        signer.initSign(kp1.getPrivate())
+        signer.update(data)
+        val sig = signer.sign()
+
+        val verifier = Signature.getInstance("Ed25519")
+        verifier.initVerify(kp2.getPublic())
+        verifier.update(data)
+        assert(!verifier.verify(sig))
+      }
+
+      test("verify fails with tampered data") {
+        val kpg = KeyPairGenerator.getInstance("Ed25519")
+        val kp = kpg.generateKeyPair()
+        val data = "original data".getBytes("UTF-8")
+
+        val signer = Signature.getInstance("Ed25519")
+        signer.initSign(kp.getPrivate())
+        signer.update(data)
+        val sig = signer.sign()
+
+        val verifier = Signature.getInstance("Ed25519")
+        verifier.initVerify(kp.getPublic())
+        verifier.update("tampered data".getBytes("UTF-8"))
+        assert(!verifier.verify(sig))
+      }
+
+      test("verify fails with tampered signature") {
+        val kpg = KeyPairGenerator.getInstance("Ed25519")
+        val kp = kpg.generateKeyPair()
+        val data = "test".getBytes("UTF-8")
+
+        val signer = Signature.getInstance("Ed25519")
+        signer.initSign(kp.getPrivate())
+        signer.update(data)
+        val sig = signer.sign()
+
+        val tampered = sig.clone()
+        tampered(0) = (tampered(0) ^ 0xff).toByte
+
+        val verifier = Signature.getInstance("Ed25519")
+        verifier.initVerify(kp.getPublic())
+        verifier.update(data)
+        // Some implementations throw SignatureException instead of returning false
+        val verified = try { verifier.verify(tampered) } catch { case _: SignatureException => false }
+        assert(!verified)
+      }
+
+      test("Ed25519 is deterministic") {
+        val kpg = KeyPairGenerator.getInstance("Ed25519")
+        val kp = kpg.generateKeyPair()
+        val data = "deterministic".getBytes("UTF-8")
+
+        val signer1 = Signature.getInstance("Ed25519")
+        signer1.initSign(kp.getPrivate())
+        signer1.update(data)
+        val sig1 = signer1.sign()
+
+        val signer2 = Signature.getInstance("Ed25519")
+        signer2.initSign(kp.getPrivate())
+        signer2.update(data)
+        val sig2 = signer2.sign()
+
+        assert(arraysEqual(sig1, sig2))
+      }
+
+      test("different keys produce different signatures") {
+        val kpg = KeyPairGenerator.getInstance("Ed25519")
+        val kp1 = kpg.generateKeyPair()
+        val kp2 = kpg.generateKeyPair()
+        val data = "same data".getBytes("UTF-8")
+
+        val signer1 = Signature.getInstance("Ed25519")
+        signer1.initSign(kp1.getPrivate())
+        signer1.update(data)
+        val sig1 = signer1.sign()
+
+        val signer2 = Signature.getInstance("Ed25519")
+        signer2.initSign(kp2.getPrivate())
+        signer2.update(data)
+        val sig2 = signer2.sign()
+
+        assert(!arraysEqual(sig1, sig2))
+      }
+
+      test("sign and verify empty message") {
+        val kpg = KeyPairGenerator.getInstance("Ed25519")
+        val kp = kpg.generateKeyPair()
+
+        val signer = Signature.getInstance("Ed25519")
+        signer.initSign(kp.getPrivate())
+        signer.update(Array.empty[Byte])
+        val sig = signer.sign()
+
+        val verifier = Signature.getInstance("Ed25519")
+        verifier.initVerify(kp.getPublic())
+        verifier.update(Array.empty[Byte])
+        assert(verifier.verify(sig))
+      }
+
+      test("sign and verify large message") {
+        val kpg = KeyPairGenerator.getInstance("Ed25519")
+        val kp = kpg.generateKeyPair()
+        val data = new Array[Byte](100000)
+        new SecureRandom().nextBytes(data)
+
+        val signer = Signature.getInstance("Ed25519")
+        signer.initSign(kp.getPrivate())
+        signer.update(data)
+        val sig = signer.sign()
+
+        val verifier = Signature.getInstance("Ed25519")
+        verifier.initVerify(kp.getPublic())
+        verifier.update(data)
+        assert(verifier.verify(sig))
+      }
+
+      test("incremental update equals single update") {
+        val kpg = KeyPairGenerator.getInstance("Ed25519")
+        val kp = kpg.generateKeyPair()
+        val data = "hello world test data".getBytes("UTF-8")
+
+        val signer1 = Signature.getInstance("Ed25519")
+        signer1.initSign(kp.getPrivate())
+        signer1.update(data)
+        val sig1 = signer1.sign()
+
+        val signer2 = Signature.getInstance("Ed25519")
+        signer2.initSign(kp.getPrivate())
+        signer2.update("hello ".getBytes("UTF-8"))
+        signer2.update("world ".getBytes("UTF-8"))
+        signer2.update("test data".getBytes("UTF-8"))
+        val sig2 = signer2.sign()
+
+        assert(arraysEqual(sig1, sig2))
+      }
+
+      test("EdDSA alias works for Signature") {
+        val kpg = KeyPairGenerator.getInstance("Ed25519")
+        val kp = kpg.generateKeyPair()
+        val data = "alias test".getBytes("UTF-8")
+
+        val signer = Signature.getInstance("EdDSA")
+        signer.initSign(kp.getPrivate())
+        signer.update(data)
+        val sig = signer.sign()
+
+        val verifier = Signature.getInstance("EdDSA")
+        verifier.initVerify(kp.getPublic())
+        verifier.update(data)
+        assert(verifier.verify(sig))
+      }
+
+      test("sign without init throws") {
+        val signer = Signature.getInstance("Ed25519")
+        val threw = try { signer.sign(); false } catch { case _: SignatureException => true }
+        assert(threw)
+      }
+
+      test("verify without init throws") {
+        val verifier = Signature.getInstance("Ed25519")
+        val threw = try { verifier.verify(new Array[Byte](64)); false } catch { case _: SignatureException => true }
+        assert(threw)
+      }
+
+      test("reuse signer for multiple signatures") {
+        val kpg = KeyPairGenerator.getInstance("Ed25519")
+        val kp = kpg.generateKeyPair()
+
+        val signer = Signature.getInstance("Ed25519")
+        signer.initSign(kp.getPrivate())
+        val verifier = Signature.getInstance("Ed25519")
+        verifier.initVerify(kp.getPublic())
+
+        signer.update("message 1".getBytes("UTF-8"))
+        val sig1 = signer.sign()
+        verifier.update("message 1".getBytes("UTF-8"))
+        assert(verifier.verify(sig1))
+
+        signer.update("message 2".getBytes("UTF-8"))
+        val sig2 = signer.sign()
+        verifier.update("message 2".getBytes("UTF-8"))
+        assert(verifier.verify(sig2))
+
+        assert(!arraysEqual(sig1, sig2))
+      }
+    }
+
+    test("key export") {
+      test("public key export is consistent") {
+        val kpg = KeyPairGenerator.getInstance("Ed25519")
+        val kp = kpg.generateKeyPair()
+        val exported1 = kp.getPublic().getEncoded()
+        val exported2 = kp.getPublic().getEncoded()
+        assert(exported1.length >= 32)
+        assert(arraysEqual(exported1, exported2))
+      }
+
+      test("private key export is consistent") {
+        val kpg = KeyPairGenerator.getInstance("Ed25519")
+        val kp = kpg.generateKeyPair()
+        val exported1 = kp.getPrivate().getEncoded()
+        val exported2 = kp.getPrivate().getEncoded()
+        assert(exported1.length >= 32)
+        assert(arraysEqual(exported1, exported2))
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Implement Ed25519 signing and verification using OpenSSL's EVP_DigestSign/EVP_DigestVerify API
- Implement Ed25519 key pair generation using EVP_PKEY_keygen with EVP_PKEY_ED25519
- Wire Signature.getInstance() and KeyPairGenerator.getInstance() to OpenSslProvider (both were stubbed with ???)
- Register Ed25519 and EdDSA alias services in OpenSslProvider

## New classes

**Implementation:**
- OpenSslEd25519Signature: EVP-backed Signature for Ed25519 sign/verify
- OpenSslEd25519KeyPairGenerator: EVP-backed key pair generation
- OpenSslEd25519PublicKey, OpenSslEd25519PrivateKey: key wrappers with raw export

**Services:**
- OpenSslSignatureService: provider service for Ed25519/EdDSA signatures
- OpenSslKeyPairGeneratorService: provider service for Ed25519/EdDSA key generation

## Changes to existing files

- internal/package.scala: added EVP_PKEY, EVP_DigestSign/Verify, raw key import/export bindings
- CtxFinalizer.scala: added register_EVP_PKEY for OpenSSL context cleanup
- OpenSslProvider.scala: registered Ed25519 Signature and KeyPairGenerator services
- Signature.scala: wired getInstance() to provider dispatch
- KeyPairGenerator.scala: wired getInstance() to provider dispatch

## Tests

19 new tests in Ed25519Suite covering key generation, sign/verify roundtrip, tampered data/signature detection, determinism, empty/large messages, incremental updates, EdDSA alias, error handling, signer reuse, and key export consistency.

## Test results

- JVM (3.3.7): 50 passed (31 existing + 19 new)
- Native (3.3.7): 3 pre-existing failures unrelated to this PR (they also fail on main without any changes -- the utest error reporting crashes with a UTFDataFormatException when serializing large failure messages)